### PR TITLE
feat: add DeleteBook use case with validation and tests

### DIFF
--- a/domain/src/use-cases/book/delete-book.spec.ts
+++ b/domain/src/use-cases/book/delete-book.spec.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { DeleteBookRequestModel, deleteBook } from './delete-book';
+import { mockBookService } from '../../services/mocks/mock-book-service';
+import { mockCryptoService } from '../../services/mocks/mock-crypto-service';
+import { BookStatus } from '../../entities';
+
+describe('Delete Book Use Case', () => {
+  const SOME_ISBN = 9781234567890;
+  const SOME_PAGES = 200;
+  const SOME_PUBLICATION_DATE = new Date('2025-01-01');
+
+  let bookService: ReturnType<typeof mockBookService>;
+  let cryptoService: ReturnType<typeof mockCryptoService>;
+
+  beforeEach(() => {
+    bookService = mockBookService();
+    cryptoService = mockCryptoService();
+  });
+
+  test('should delete book successfully when book exists', async () => {
+    const bookId = await cryptoService.generateUUID();
+    const existingBook = {
+      id: bookId,
+      title: 'Test Book',
+      ISBN: SOME_ISBN,
+      pages: SOME_PAGES,
+      publicationDate: SOME_PUBLICATION_DATE,
+      publisher: 'Test Publisher',
+      status: BookStatus.AVAILABLE,
+      totalLoans: 0,
+      isPopular: false,
+      entryDate: new Date('2020-01-01'),
+    };
+
+    await bookService.save(existingBook);
+
+    const deleteRequest: DeleteBookRequestModel = {
+      bookId,
+    };
+
+    const result = await deleteBook({ bookService }, deleteRequest);
+
+    expect(result.success).toBe(true);
+    expect(result.message).toBe('Book deleted successfully');
+  });
+
+  test('should fail when book does not exist', async () => {
+    const nonExistentId = await cryptoService.generateUUID();
+
+    const deleteRequest: DeleteBookRequestModel = {
+      bookId: nonExistentId,
+    };
+
+    const result = await deleteBook({ bookService }, deleteRequest);
+
+    expect(result.success).toBe(false);
+    expect(result.message).toBe('Book not found');
+  });
+});

--- a/domain/src/use-cases/book/delete-book.ts
+++ b/domain/src/use-cases/book/delete-book.ts
@@ -1,0 +1,36 @@
+import { BookService } from '../../services/book-service';
+import { UUID } from '../../types/uuid';
+
+export interface DeleteBookDependencies {
+  bookService: BookService;
+}
+
+export interface DeleteBookRequestModel {
+  bookId: UUID;
+}
+
+export interface DeleteBookResponseModel {
+  success: boolean;
+  message: string;
+}
+
+export const deleteBook = async (
+  { bookService }: DeleteBookDependencies,
+  request: DeleteBookRequestModel
+): Promise<DeleteBookResponseModel> => {
+  const existingBook = await bookService.findById(request.bookId);
+
+  if (!existingBook) {
+    return {
+      success: false,
+      message: 'Book not found',
+    };
+  }
+
+  await bookService.delete(request.bookId);
+
+  return {
+    success: true,
+    message: 'Book deleted successfully',
+  };
+};


### PR DESCRIPTION
# Overview
This PR adds the `DeleteBook` use case to enable deleting existing books with proper validation in the BookLend library management system.

## Changes
* Added `DeleteBook` use case for book deletion
* Implemented validation for book existence before deletion
* Created comprehensive test suite with mock services
* Applied clean architecture principles with dependency injection

### Use Case Added
**DeleteBook**
* **Input**: Book ID to delete
* **Output**: Success/failure response with deletion confirmation
* **Dependencies**: `BookService` for data operations
* **Validation**: Book existence check before deletion

### Notes
The use case ensures only existing books can be deleted and provides clear error messages for non-existent books.